### PR TITLE
setting same password in chaibuilder for account show error

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -24,7 +24,7 @@ export default function LoginForm() {
       toast.success("Login successful", { position: "top-right" });
       router.push("/sites");
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to login", {
+      toast.error(error instanceof Error && error.message ? "Invalid login credentials" : "Failed to login", {
         position: "top-right",
       });
       setIsLoading(false);

--- a/components/auth/update-password.tsx
+++ b/components/auth/update-password.tsx
@@ -56,7 +56,7 @@ export default function UpdatePassword({
       router.push("/sites");
     } catch (error) {
       setError(
-        error instanceof Error ? error.message : "Failed to update password"
+        error instanceof Error && error.message ? "Please enter new valid password " : "Failed to update password"
       );
     } finally {
       setIsLoading(false);

--- a/components/auth/update-password.tsx
+++ b/components/auth/update-password.tsx
@@ -84,7 +84,7 @@ export default function UpdatePassword({
   return (
     <>
       {error && (
-        <Alert variant="destructive" className="text-red-500 text-center">
+        <Alert variant="destructive" className="text-red-500 text-center  mb-4">
           {error}
         </Alert>
       )}


### PR DESCRIPTION
[Screencast from 2025-07-30 12-55-37.webm](https://github.com/user-attachments/assets/14831db8-8b29-4d13-b2d1-4c85ab7b4e15)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for login and password update forms to display clearer, fixed notifications instead of technical error details.
  * Enhanced spacing in the password update form for better visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->